### PR TITLE
Bugfix/multiple values for display with label

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ def badge_callback(request):
 
 Unfold introduces it's own `unfold.decorators.display` decorator. By default it has exactly same behavior as native `django.contrib.admin.decorators.display` but it adds same customizations which helps to extends default logic.
 
-`@display(label=True, mappings={"value1": "success"})` displays a result as a label. This option fits for different types of statuses. `mappings` parameter is a dict responsible for displaying labels in different colors at the moment these color combinations are supported: success(green), info(blue), danger(red) and warning(orange).
+`@display(label=True)`, `@display(label={"value1": "success"})` displays a result as a label. This option fits for different types of statuses. Label can be either boolean indicating we want to use label with default color or dict where the dict is responsible for displaying labels in different colors. At the moment these color combinations are supported: success(green), info(blue), danger(red) and warning(orange).
 
 `@display(header=True)` displays in results list two information in one table cell. Good example is when we want to display customer information, first line is going to be customer's name and right below the name display corresponding email address. Method with such a decorator is supposed to return a list with two elements `return "Full name", "E-mail address"`.
 

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -42,7 +42,8 @@ def display_for_label(value, empty_value_display, label):
                 value = value[0]
         elif value in label:
             label_type = label[value]
-    elif isinstance(label, (label, tuple)):
+
+    if isinstance(value, tuple) or isinstance(value, list):
         multiple = True
 
     return mark_safe(


### PR DESCRIPTION
Providing something other than dict to `label` in `display` decorator caused TypeError by `isinstance` check.
Therefore `multiple` did not work correctly. Fixed it by checking whether the `value` is list or tuple. Now the list values will be displayed as separate "tiles" in admin.

Also updated the documentation since `mappings` attribute does not exist anymore in `display` and it was merged into `label` attribute.