### PR TITLE
Add option to insert HTML attributes inside actions detail <a/> tag

### DIFF
--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -384,6 +384,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
                 actions.append(
                     {
                         "title": action["description"],
+                        "attrs": action["method"].attrs,
                         "path": reverse(
                             f"admin:{action['action_name']}", args=(object_id,)
                         ),
@@ -407,6 +408,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
         actions = [
             {
                 "title": action["description"],
+                "attrs": action["method"].attrs,
                 "path": reverse(f"admin:{action['action_name']}"),
             }
             for action in self.get_actions_list()

--- a/src/unfold/templates/admin/change_form.html
+++ b/src/unfold/templates/admin/change_form.html
@@ -60,7 +60,11 @@
             {% if actions_detail %}
                 <div class="bg-gray-50 flex justify-end mb-4 p-3 rounded-md">
                     {% for action in actions_detail %}
-                        <a href="{{ action.path }}" class="bg-white text-gray-500 border cursor-pointer flex font-medium items-center px-3 py-2 mr-3 rounded-md shadow-sm text-sm">
+                        <a href="{{ action.path }}" class="bg-white text-gray-500 border cursor-pointer flex font-medium items-center px-3 py-2 mr-3 rounded-md shadow-sm text-sm"
+                            {% for attr_name, attr_value in action.attrs.items %}
+                                {{ attr_name }}="{{ attr_value }}"
+                            {% endfor %}
+                        >
                             {{ action.title }}
                         </a>
                     {% endfor %}


### PR DESCRIPTION
This patch will enable usage of attrs parameter used in `decorators.action` decorator to insert custom HTML attributes