### PR TITLE
Added styling for own password change form

### DIFF
--- a/src/unfold/forms.py
+++ b/src/unfold/forms.py
@@ -3,6 +3,9 @@ from django.contrib.admin.forms import AdminAuthenticationForm
 from django.contrib.auth.forms import (
     AdminPasswordChangeForm as BaseAdminPasswordChangeForm,
 )
+from django.contrib.admin.forms import (
+    AdminPasswordChangeForm as BaseAdminOwnPasswordChangeForm
+)
 from django.contrib.auth.forms import UserChangeForm as BaseUserChangeForm
 from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
 from django.utils.translation import gettext_lazy as _
@@ -66,3 +69,12 @@ class AdminPasswordChangeForm(BaseAdminPasswordChangeForm):
 
         self.fields["password1"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
         self.fields["password2"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
+
+
+class AdminOwnPasswordChangeForm(BaseAdminOwnPasswordChangeForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(kwargs.pop('user'), *args, **kwargs)
+
+        self.fields["old_password"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
+        self.fields["new_password1"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
+        self.fields["new_password2"].widget.attrs["class"] = " ".join(INPUT_CLASSES)

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -6,7 +6,7 @@ from django.core.validators import EMPTY_VALUES
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.urls import path, reverse_lazy
+from django.urls import path, reverse_lazy, reverse
 from django.utils.module_loading import import_string
 
 from .settings import get_config
@@ -151,6 +151,20 @@ class UnfoldAdminSite(AdminSite):
             extra_context.update({REDIRECT_FIELD_NAME: redirect_field_name})
 
         return super().login(request, extra_context)
+
+    def password_change(self, request, extra_context=None):
+        from .forms import AdminOwnPasswordChangeForm
+        from django.contrib.auth.views import PasswordChangeView
+        url = reverse('admin:password_change_done', current_app=self.name)
+        defaults = {
+            'form_class': AdminOwnPasswordChangeForm,
+            'success_url': url,
+            'extra_context': {**self.each_context(request), **(extra_context or {})},
+        }
+        if self.password_change_template is not None:
+            defaults['template_name'] = self.password_change_template
+        request.current_app = self.name
+        return PasswordChangeView.as_view(**defaults)(request)
 
     def get_sidebar_list(self, request):
         navigation = get_config()["SIDEBAR"].get("navigation")

--- a/src/unfold/templates/registration/password_change_done.html
+++ b/src/unfold/templates/registration/password_change_done.html
@@ -1,0 +1,29 @@
+{% extends "admin/base_site.html" %}
+{% load admin_urls i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% if not is_popup %}
+    {% block breadcrumbs %}
+        <div class="px-12">
+            <div class="container mb-12 mx-auto -my-3">
+                <ul class="flex">
+                    {% url 'admin:index' as link %}
+                    {% trans 'Home' as name %}
+                    {% include 'unfold/helpers/breadcrumb_item.html' with link=link name=name %}
+
+                    {% translate 'Change password' as breadcrumb_name %}
+                    {% include 'unfold/helpers/breadcrumb_item.html' with link='' name=breadcrumb_name %}
+                </ul>
+            </div>
+        </div>
+    {% endblock %}
+{% endif %}
+
+{% block content %}
+    <div id="content-main">
+      <p class="bg-primary-100 mb-8 text-primary-600 px-3 py-3 rounded-md text-sm">
+        {% translate 'Your password was changed.' %}
+      </p>
+    </div>
+{% endblock %}

--- a/src/unfold/templates/registration/password_change_form.html
+++ b/src/unfold/templates/registration/password_change_form.html
@@ -1,0 +1,135 @@
+{% extends "admin/base_site.html" %}
+{% load admin_urls i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% if not is_popup %}
+    {% block breadcrumbs %}
+        <div class="px-12">
+            <div class="container mb-12 mx-auto -my-3">
+                <ul class="flex">
+                    {% url 'admin:index' as link %}
+                    {% trans 'Home' as name %}
+                    {% include 'unfold/helpers/breadcrumb_item.html' with link=link name=name %}
+
+                    {% translate 'Change password' as breadcrumb_name %}
+                    {% include 'unfold/helpers/breadcrumb_item.html' with link='' name=breadcrumb_name %}
+                </ul>
+            </div>
+        </div>
+    {% endblock %}
+{% endif %}
+
+{% block content %}
+    <div id="content-main">
+        <form{% if form_url %} action="{{ form_url }}"{% endif %} method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
+            <input type="text" name="username" value="{{ original.get_username }}" class="hidden">
+
+            <div>
+                {% if is_popup %}
+                    <input type="hidden" name="{{ is_popup_var }}" value="1">
+                {% endif %}
+
+                {% if form.errors %}
+                    <p class="errornote bg-red-100 mb-8 text-red-600 px-3 py-3 rounded-md text-sm">
+                        {% if form.errors.items|length == 1 %}
+                            {% translate "Please correct the error below." %}
+                        {% else %}
+                            {% translate "Please correct the errors below." %}
+                        {% endif %}
+                    </p>
+                {% endif %}
+
+                <p class="bg-primary-100 mb-8 text-primary-600 px-3 py-3 rounded-md text-sm">
+                  {% translate 'Please enter your old password, for security’s sake, and then enter your new password twice so we can verify you typed it in correctly.' %}
+                </p>
+
+                <div class="flex mb-6 flex-col">
+                    <label for="{{ form.old_password.id_for_label }}" class="block font-medium mb-2 text-gray-900 text-sm">
+                        {{ form.old_password.label }}
+                    </label>
+
+                    {{ form.old_password }}
+
+                    {{ form.old_password.errors }}
+
+                    {% if form.old_password.errors %}
+                        <div class="mt-1 text-red-600 text-sm">
+                            <ul>
+                                {% for error in form.old_password.errors %}
+                                    <li>
+                                        {{ error }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    {% if form.old_password.help_text %}
+                        <div class="leading-relaxed mt-2 text-gray-500 text-xs">
+                            {{ form.old_password.help_text|safe }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="flex mb-6 flex-col">
+                    <label for="{{ form.new_password1.id_for_label }}" class="block font-medium mb-2 text-gray-900 text-sm">
+                        {{ form.new_password1.label }}
+                    </label>
+
+                    {{ form.new_password1 }}
+
+                    {{ form.new_password1.errors }}
+
+                    {% if form.new_password1.errors %}
+                        <div class="mt-1 text-red-600 text-sm">
+                            <ul>
+                                {% for error in form.new_password1.errors %}
+                                    <li>
+                                        {{ error }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    {% if form.new_password1.help_text %}
+                        <div class="leading-relaxed mt-2 text-gray-500 text-xs">
+                            {{ form.new_password1.help_text|safe }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="flex mb-6 flex-col">
+                    <label for="{{ form.new_password2.id_for_label }}" class="block font-medium mb-2 text-gray-900 text-sm">
+                        {{ form.new_password2.label }}
+                    </label>
+
+                    {{ form.new_password2 }}
+
+                    {% if form.new_password2.errors %}
+                        <div class="mt-1 text-red-600 text-sm">
+                            <ul>
+                                {% for error in form.new_password2.errors %}
+                                    <li>
+                                        {{ error }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    {% if form.new_password2.help_text %}
+                        <div class="leading-relaxed mt-2 text-gray-500 text-xs">
+                            {{ form.new_password2.help_text|safe }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <button type="submit" class="bg-primary-600 border border-transparent font-medium px-3 py-2 rounded-md text-sm text-white">
+                    {% translate 'Change password' %}
+                </button>
+            </div>
+        </form>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Reused `change_password.html` template for own password change template.

Before:
![Screenshot 2022-09-13 at 19 03 03](https://user-images.githubusercontent.com/22654504/190171176-59e3dffc-9e18-4e83-8410-9ef91a44b54c.png)

![Screenshot 2022-09-14 at 15 20 56](https://user-images.githubusercontent.com/22654504/190171233-f7a71a3b-d92b-45d1-91e6-ba286208ec2a.png)

After:
![Screenshot 2022-09-14 at 15 40 13](https://user-images.githubusercontent.com/22654504/190171322-c06e91f6-39ee-4b49-a3c0-217494f21776.png)

![Screenshot 2022-09-14 at 15 39 59](https://user-images.githubusercontent.com/22654504/190171376-474c099e-7abe-4afc-8bb6-03710592907f.png)
