### PR TITLE
feat: Add dynamic sidebar permissions customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,20 @@ UNFOLD = {
         {
             "models": [
                 "app_label.model_name_in_lowercase",
+                "app_label.model_name2_in_lowercase",
             ],
             "items": [
                 {
                     "title": _("Your custom title"),
                     "link": reverse_lazy("admin:app_label_model_name_changelist"),
                 },
+                {
+                    "title": _("Tab 2 with permission"),
+                    "link": reverse_lazy("admin:app_label_model_name_2_changelist"),
+                    "permission": "sample_app.permission_callback",
+                },
             ],
+            "default_permission": "sample_app.permission_callback",
         },
     ],
 }

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ UNFOLD = {
     "SIDEBAR": {
         "show_search": False,  # Search in applications and models names
         "show_all_applications": False,  # Dropdown with all applications and models
+        "default_permission": "sample_app.permission_callback",  # Decide who can see sidebar items (default True)
         "navigation": [
             {
                 "title": _("Navigation"),
@@ -166,6 +167,7 @@ UNFOLD = {
                         "icon": "dashboard",  # Supported icon set: https://fonts.google.com/icons
                         "link": reverse_lazy("admin:index"),
                         "badge": "sample_app.badge_callback",
+                        "permission": "sample_app.permission_callback",  # Override permission for a specific item
                     },
                     {
                         "title": _("Users"),
@@ -207,6 +209,10 @@ def dashboard_callback(request, context):
 
 def badge_callback(request):
     return 3
+
+
+def permission_callback(request):
+    return True
 ```
 
 ### Available unfold.admin.ModelAdmin options

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ UNFOLD = {
     "SIDEBAR": {
         "show_search": False,  # Search in applications and models names
         "show_all_applications": False,  # Dropdown with all applications and models
-        "default_permission": "sample_app.permission_callback",  # Decide who can see sidebar items (default True)
+        "default_visibility_callback": "sample_app.visibility_callback",  # Decide who can see sidebar items (default True)
         "navigation": [
             {
                 "title": _("Navigation"),
@@ -167,7 +167,7 @@ UNFOLD = {
                         "icon": "dashboard",  # Supported icon set: https://fonts.google.com/icons
                         "link": reverse_lazy("admin:index"),
                         "badge": "sample_app.badge_callback",
-                        "permission": "sample_app.permission_callback",  # Override permission for a specific item
+                        "visibility_callback": "sample_app.visibility_callback",  # Override visibility for a specific item
                     },
                     {
                         "title": _("Users"),
@@ -190,12 +190,12 @@ UNFOLD = {
                     "link": reverse_lazy("admin:app_label_model_name_changelist"),
                 },
                 {
-                    "title": _("Tab 2 with permission"),
+                    "title": _("Tab 2 with visibility"),
                     "link": reverse_lazy("admin:app_label_model_name_2_changelist"),
-                    "permission": "sample_app.permission_callback",
+                    "visibility_callback": "sample_app.visibility_callback",
                 },
             ],
-            "default_permission": "sample_app.permission_callback",
+            "default_visibility_callback": "sample_app.visibility_callback",
         },
     ],
 }
@@ -218,7 +218,7 @@ def badge_callback(request):
     return 3
 
 
-def permission_callback(request):
+def visibility_callback(request):
     return True
 ```
 

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -183,18 +183,18 @@ class UnfoldAdminSite(AdminSite):
 
             return False
 
-        def _filter_by_permission(item):
-            if "permission" in item:
-                return import_string(item["permission"])(request)
+        def _filter_by_visibility(item):
+            if "visibility_callback" in item:
+                return import_string(item["visibility_callback"])(request)
 
-            if default_permission := get_config()["SIDEBAR"].get("default_permission"):
-                return import_string(default_permission)(request)
+            if default_visibility_cb := get_config()["SIDEBAR"].get("default_visibility_callback"):
+                return import_string(default_visibility_cb)(request)
 
             return True
 
         for group in navigation:
             group["items"] = [
-                item for item in group["items"] if _filter_by_permission(item)
+                item for item in group["items"] if _filter_by_visibility(item)
             ]
             for item in group["items"]:
                 item["active"] = False
@@ -229,19 +229,19 @@ class UnfoldAdminSite(AdminSite):
         return results
 
     def get_tab_list(self, request):
-        def _filter_by_permission(item, default_permission=None):
-            if "permission" in item:
-                return import_string(item["permission"])(request)
+        def _filter_by_visibility(item, default_visibility_cb=None):
+            if "visibility_callback" in item:
+                return import_string(item["visibility_callback"])(request)
 
-            if default_permission:
-                return import_string(default_permission)(request)
+            if default_visibility_cb:
+                return import_string(default_visibility_cb)(request)
 
             return True
 
         def _filter_tab_items(tab_set):
-            default_permission = tab_set.get("default_permission")
+            default_visibility_cb = tab_set.get("default_visibility_callback")
             tab_set['items'] = [
-                item for item in tab_set['items'] if _filter_by_permission(item, default_permission)
+                item for item in tab_set['items'] if _filter_by_visibility(item, default_visibility_cb)
             ]
             return tab_set
 

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -182,7 +182,19 @@ class UnfoldAdminSite(AdminSite):
 
             return False
 
+        def _filter_by_permission(item):
+            if "permission" in item:
+                return import_string(item["permission"])(request)
+
+            if default_permission := get_config()["SIDEBAR"].get("default_permission"):
+                return import_string(default_permission)(request)
+
+            return True
+
         for group in navigation:
+            group["items"] = [
+                item for item in group["items"] if _filter_by_permission(item)
+            ]
             for item in group["items"]:
                 item["active"] = False
                 item["active"] = _get_is_active(item["link"])
@@ -210,7 +222,8 @@ class UnfoldAdminSite(AdminSite):
                     except ImportError:
                         pass
 
-            results.append(group)
+            if group["items"]:
+                results.append(group)
 
         return results
 

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from http import HTTPStatus
 
 from django.contrib.admin import AdminSite
@@ -168,7 +169,7 @@ class UnfoldAdminSite(AdminSite):
         return PasswordChangeView.as_view(**defaults)(request)
 
     def get_sidebar_list(self, request):
-        navigation = get_config()["SIDEBAR"].get("navigation", [])
+        navigation = deepcopy(get_config()["SIDEBAR"].get("navigation", []))
         results = []
 
         def _get_is_active(link):


### PR DESCRIPTION
This PR introduces sidebar customisation via permissions.

It is now possible to provide visibility callback to "SIDEBAR"."default_visibility" in UNFOLD settings to apply permissions to all sidebar items. You can override visibility of specific items to users by filling "visibility_callback" for each item.

If not item is visible for user, its group title also won't be shown. If "default_visibility_callback" is not specified, it will act as `lambda request: True` (anyone can see everything).