### PR TITLE
fix: add link color

### DIFF
--- a/src/unfold/templates/admin/change_list_object_tools.html
+++ b/src/unfold/templates/admin/change_list_object_tools.html
@@ -7,8 +7,8 @@
 
             <span class="block bg-gray-200 h-5 mr-4 w-px dark:bg-gray-700"></span>
 
-            <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink bg-primary-600 block flex items-center h-9 justify-center -my-1 rounded-full w-9" title="{% blocktranslate with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktranslate %}">
-                <span class="material-symbols-outlined text-white">add</span>
+            <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink bg-primary-600 block flex items-center h-9 justify-center -my-1 rounded-full w-9 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" title="{% blocktranslate with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktranslate %}">
+                <span class="material-symbols-outline">add</span>
             </a>
         </li>
     {% endif %}


### PR DESCRIPTION
This change fixes the color of the add link in the navigation bar so that it is visible. There was an issue with the add link in the navigation bar being white and therefore invisible in light mode. I think it's been missing since #26 or #43.

Before:
![Screen Shot 2023-03-06 at 12 01 18](https://user-images.githubusercontent.com/11746585/223009743-9701ec0d-f053-4700-a7cf-7c38683e85b2.png)
![Screen Shot 2023-03-06 at 12 01 23](https://user-images.githubusercontent.com/11746585/223009744-d805985a-b678-448f-b82d-cf9823770b9a.png)

After:
![Screen Shot 2023-03-06 at 12 01 06](https://user-images.githubusercontent.com/11746585/223009739-8c45433c-98df-4fb4-90a9-1456fc95fdaa.png)
![Screen Shot 2023-03-06 at 12 01 15](https://user-images.githubusercontent.com/11746585/223009742-066c9932-7078-4fea-ab4b-5f984b8cfcd1.png)
