### PR TITLE
Override widget for GenericIPAddress fields

### DIFF
--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -67,6 +67,7 @@ FORMFIELD_OVERRIDES = {
     models.EmailField: {"widget": UnfoldAdminEmailInputWidget},
     models.CharField: {"widget": UnfoldAdminTextInputWidget},
     models.URLField: {"widget": UnfoldAdminTextInputWidget},
+    models.GenericIPAddressField: {"widget": UnfoldAdminTextInputWidget},
     models.UUIDField: {"widget": UnfoldAdminUUIDInputWidget},
     models.TextField: {"widget": UnfoldAdminTextareaWidget},
     models.NullBooleanField: {"widget": UnfoldAdminNullBooleanSelectWidget},


### PR DESCRIPTION
Currently fields of type GenericIPAddress have no style applied to them. This PR overrides adds them to the FORMFIELD_OVERRIDES so that the necessary classes are applied to them.